### PR TITLE
Fix support for IE --bitness 32

### DIFF
--- a/webdrivermanager/webdrivermanager.py
+++ b/webdrivermanager/webdrivermanager.py
@@ -617,6 +617,8 @@ class IEDriverManager(WebDriverManagerBase):
         local_osname = self.os_name
         if self.bitness == "64":
             local_osname = "x"
+        elif self.bitness == "32":
+            local_osname = "Win"
         matcher = r'.*/.*_{0}{1}_{2}'.format(local_osname, self.bitness, version)
         entry = [entry for entry in self._drivers if re.match(matcher, entry)]
 


### PR DESCRIPTION
FIxes the URL composition for IE driver on win 32 bit. 
Filenames are named "Win32", so without the case change the tool is unable to find a suitable version.
Thanks,
 Luciano