### PR TITLE
Improve regex for chrome version

### DIFF
--- a/webdrivermanager/webdrivermanager.py
+++ b/webdrivermanager/webdrivermanager.py
@@ -429,7 +429,7 @@ class ChromeDriverManager(WebDriverManagerBase):
         version = version + '.0' if '.' not in version else version
         matcher = r'{0}.*/.*{1}{2}.*'.format(version, self.os_name, local_bitness)
 
-        entry = [obj for obj in chrome_driver_objects['items'] if re.search(matcher, obj['name'])]
+        entry = [obj for obj in chrome_driver_objects['items'] if re.match(matcher, obj['name'])]
         if not entry:
             raise_runtime_error('Error, unable to find appropriate download for {0}{1}.'.format(self.os_name, self.bitness))
 

--- a/webdrivermanager/webdrivermanager.py
+++ b/webdrivermanager/webdrivermanager.py
@@ -426,15 +426,16 @@ class ChromeDriverManager(WebDriverManagerBase):
         else:
             local_bitness = self.bitness
 
-        matcher = r'{0}/.*{1}{2}.*'.format(version, self.os_name, local_bitness)
+        version = version + '.0' if '.' not in version else version
+        matcher = r'{0}.*/.*{1}{2}.*'.format(version, self.os_name, local_bitness)
 
-        entry = [obj for obj in chrome_driver_objects['items'] if re.match(matcher, obj['name'])]
+        entry = [obj for obj in chrome_driver_objects['items'] if re.search(matcher, obj['name'])]
         if not entry:
             raise_runtime_error('Error, unable to find appropriate download for {0}{1}.'.format(self.os_name, self.bitness))
 
         url = entry[0]['mediaLink']
         filename = os.path.basename(entry[0]['name'])
-        return (url, filename)
+        return url, filename
 
 
 class OperaChromiumDriverManager(WebDriverManagerBase):


### PR DESCRIPTION
Hey there! 

There was a small issue with downloading specific chromedrivers as the versions have gotten extra long and extravagant. For example to download chromedriver version 80, you would have to type out `webdrivermanager chrome:83.0.4103.14` ... man that is brutal! 

I went ahead and improved the regex for the `name` key from the API request to account for just getting a specific version by doing something like `chrome:83` or `chrome:80` to keep things simple, and of course you can go deeper in the version number, as i just just add `.0` to the version number to make sure it doesn't pick up a random minor version when doing the regex. ( most major version number releases will have something like 81.0 or 83.0 )... so this should suffice. 

With this you can just write `webdriveragent chrome:83` now and it will download chromdriver version 83. 

cheers 