### PR TITLE
- Added support to download the latest of a major line for Chrome drivers (e.g. 85 or 85.0.4183)

### DIFF
--- a/webdrivermanager/webdrivermanager.py
+++ b/webdrivermanager/webdrivermanager.py
@@ -382,10 +382,13 @@ class ChromeDriverManager(WebDriverManagerBase):
 
     chrome_driver_base_url = 'https://www.googleapis.com/storage/v1/b/chromedriver'
 
-    def _get_latest_version_number(self):
-        resp = requests.get(self.chrome_driver_base_url + '/o/LATEST_RELEASE')
+    def _get_latest_version_number(self, major=""):
+        url = self.chrome_driver_base_url + '/o/LATEST_RELEASE'
+        if major != "":
+            url = url + "_" + major
+        resp = requests.get(url)
         if resp.status_code != 200:
-            raise_runtime_error('Error, unable to get version number for latest release, got code: {0}'.format(resp.status_code))
+            raise_runtime_error('Error, unable to get version number for latest release {1}, got code: {0}'.format(resp.status_code, major))
 
         latest_release = requests.get(resp.json()['mediaLink'])
         return latest_release.text
@@ -414,6 +417,10 @@ class ChromeDriverManager(WebDriverManagerBase):
         """
         if version == 'latest':
             version = self._get_latest_version_number()
+        elif re.match("^[0-9]+$", version) or re.match("^[0-9]+\.[0-9]+\.[0-9]+$", version):
+            major = version
+            version = self._get_latest_version_number(major)
+            LOGGER.debug('Latest version %s found from required major %s', version, major)
 
         LOGGER.debug('Detected OS: %sbit %s', self.bitness, self.os_name)
 


### PR DESCRIPTION
Since the Chrome REST API `https://www.googleapis.com/storage/v1/b/chromedriver` to download chrome drivers seems to support:
- `LATEST_RELEASE` for the lastest version
- `LATEST_RELEASE_vv` the the latest version of the `vv` major version
- `LATEST_RELEASE_vv.dd,mm` the the latest version of the `vv.dd.mm` version (then having only the last build number omitted)
with this change it is possible to specify a partial version for chrome driver, in order to download the latest driver.

For example:
webdrivermanager chrome:85
webdrivermanager chrome:81.0.4044

This is requires since Chrome releases are not often in sync with the driver version til the forth number.
