### PR TITLE
Add baseclass methods for parsing latest and compatible versions, compatible Firefox support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,5 +38,5 @@ directory = report
 VCS = git
 style = pep440
 versionfile_source = src/webdrivermanager/_version.py
-versionfile_build = src/webdrivermanager/_version.py
+versionfile_build = webdrivermanager/_version.py
 tag_prefix =

--- a/src/webdrivermanager/__main__.py
+++ b/src/webdrivermanager/__main__.py
@@ -71,7 +71,7 @@ def main():
         if ":" in browser:
             browser, version = browser.split(":")
         else:
-            version = "latest"
+            version = "compatible"
 
         if browser.lower() in DOWNLOADERS.keys():
             print(f'Downloading WebDriver for browser: "{browser}"')

--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -148,7 +148,7 @@ class WebDriverManagerBase:
             except NotImplementedError:
                 pass
             except Exception as exc:
-                LOGGER.info("Failed to parse compatible version: %s", exc)
+                LOGGER.warning("Failed to parse compatible version: %s", exc)
             method = "latest"
 
         if method == "latest":

--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -127,8 +127,34 @@ class WebDriverManagerBase:
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def get_latest_version(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_compatible_version(self):
+        raise NotImplementedError
+
     def get_driver_filename(self):
         return self.driver_filenames[self.os_name]
+
+    def _parse_version(self, version):
+        method = version.strip().lower()
+
+        # Attempt to match webdriver to current browser version, if supported
+        if method == "compatible":
+            try:
+                return self.get_compatible_version()
+            except NotImplementedError:
+                pass
+            except Exception as exc:
+                LOGGER.info("Failed to parse compatible version: %s", exc)
+            method = "latest"
+
+        if method == "latest":
+            return self.get_latest_version()
+        else:
+            return version
 
     def _get_latest_version_with_github_page_fallback(self, url, fallback_url, required_version):
         version = None

--- a/src/webdrivermanager/edgechromium.py
+++ b/src/webdrivermanager/edgechromium.py
@@ -21,6 +21,43 @@ class EdgeChromiumDriverManager(WebDriverManagerBase):
         "linux": None,
     }
 
+    def get_download_path(self, version="latest"):
+        version = self._parse_version(version)
+        return self.download_root / "edgechromium" / version
+
+    def get_download_url(self, version="latest"):
+        """
+        Method for getting the download URL for the Google Chome driver binary.
+
+        :param version: String representing the version of the web driver binary to download.  For example, "2.39".
+                        Default if no version is specified is "latest".  The version string should match the version
+                        as specified on the download page of the webdriver binary.
+        :returns: The download URL for the Internet Explorer driver binary.
+        """
+        version = self._parse_version(version)
+
+        if not self._drivers:
+            self._populate_cache(self.edgechromium_driver_base_url)
+
+        LOGGER.debug("Detected OS: %sbit %s", self.bitness, self.os_name)
+        local_osname = self.os_name
+        matcher = r".*/{0}/edgedriver_{1}{2}".format(version, local_osname, self.bitness)
+        entry = [entry for entry in self._drivers if re.match(matcher, entry)]
+        if not entry:
+            raise_runtime_error(f"Error, unable to find appropriate download for {self.os_name}{self.bitness}.")
+
+        url = entry[0]
+        filename = Path(entry[0]).name
+        return (url, filename)
+
+    def get_latest_version(self):
+        if self._drivers is None or self._versions is None:
+            self._populate_cache(self.edgechromium_driver_base_url)
+        return ".".join(map(str, max(self._versions)))
+
+    def get_compatible_version(self):
+        raise NotImplementedError
+
     def _extract_ver(self, s):
         matcher = r".*\/edgewebdriver\/([\d.]+)\/edgedriver_.*\.zip"
         ret = re.match(matcher, s)
@@ -37,41 +74,3 @@ class EdgeChromiumDriverManager(WebDriverManagerBase):
         drivers = filter(lambda entry: f"edgedriver_{arch_matcher}" in entry.contents[0], soup.find_all("url"))
         self._drivers = list(map(lambda entry: entry.contents[0], drivers))
         self._versions = set(map(lambda entry: versiontuple(self._extract_ver(entry)), self._drivers))
-
-    def _get_latest_version_number(self):
-        if self._drivers is None or self._versions is None:
-            self._populate_cache(self.edgechromium_driver_base_url)
-        return ".".join(map(str, max(self._versions)))
-
-    def get_download_path(self, version="latest"):
-        if version == "latest":
-            ver = self._get_latest_version_number()
-        else:
-            ver = version
-        return self.download_root / "edgechromium" / ver
-
-    def get_download_url(self, version="latest"):
-        """
-        Method for getting the download URL for the Google Chome driver binary.
-
-        :param version: String representing the version of the web driver binary to download.  For example, "2.39".
-                        Default if no version is specified is "latest".  The version string should match the version
-                        as specified on the download page of the webdriver binary.
-        :returns: The download URL for the Internet Explorer driver binary.
-        """
-        if version == "latest":
-            version = self._get_latest_version_number()
-
-        if not self._drivers:
-            self._populate_cache(self.edgechromium_driver_base_url)
-
-        LOGGER.debug("Detected OS: %sbit %s", self.bitness, self.os_name)
-        local_osname = self.os_name
-        matcher = r".*/{0}/edgedriver_{1}{2}".format(version, local_osname, self.bitness)
-        entry = [entry for entry in self._drivers if re.match(matcher, entry)]
-        if not entry:
-            raise_runtime_error(f"Error, unable to find appropriate download for {self.os_name}{self.bitness}.")
-
-        url = entry[0]
-        filename = Path(entry[0]).name
-        return (url, filename)

--- a/src/webdrivermanager/gecko.py
+++ b/src/webdrivermanager/gecko.py
@@ -3,7 +3,7 @@ import requests
 import os
 from urllib.parse import urlparse
 from .base import WebDriverManagerBase
-from .misc import LOGGER, raise_runtime_error
+from .misc import LOGGER, raise_runtime_error, get_output
 
 
 class GeckoDriverManager(WebDriverManagerBase):
@@ -11,18 +11,22 @@ class GeckoDriverManager(WebDriverManagerBase):
 
     gecko_driver_releases_url = "https://api.github.com/repos/mozilla/geckodriver/releases/"
     fallback_url = "https://github.com/mozilla/geckodriver/releases/"
+
     driver_filenames = {
         "win": "geckodriver.exe",
         "mac": "geckodriver",
         "linux": "geckodriver",
     }
 
+    firefox_version_commands = {
+        "win": ["reg", "query", r"HKEY_CURRENT_USER\Software\Mozilla\Mozilla Firefox", "/v", "CurrentVersion"],
+        "linux": ["firefox", "--version"],
+        "mac": ["/Applications/Firefox.app/Contents/MacOS/firefox-bin", "--version"],
+    }
+
     def get_download_path(self, version="latest"):
-        if version == "latest":
-            ver = self._get_latest_version_with_github_page_fallback(self.gecko_driver_releases_url, self.fallback_url, version)
-        else:
-            ver = version
-        return self.download_root / "gecko" / ver
+        version = self._parse_version(version)
+        return self.download_root / "gecko" / version
 
     def get_download_url(self, version="latest"):
         """
@@ -33,12 +37,11 @@ class GeckoDriverManager(WebDriverManagerBase):
                         as specified on the download page of the webdriver binary.
         :returns: The download URL for the Gecko (Mozilla Firefox) driver binary.
         """
-        if version == "latest":
-            gecko_driver_version_release_url = self.gecko_driver_releases_url + version
-        else:
-            gecko_driver_version_release_url = self.gecko_driver_releases_url + "tags/" + version
-        LOGGER.debug("Attempting to access URL: %s", gecko_driver_version_release_url)
-        response = requests.get(gecko_driver_version_release_url)
+        version = self._parse_version(version)
+        releases_url = f"{self.gecko_driver_releases_url}tags/{version}"
+
+        LOGGER.debug("Attempting to access URL: %s", releases_url)
+        response = requests.get(releases_url)
         if response.ok:
             url = self._parse_github_api_response(version, response)
         elif response.status_code == 403:
@@ -49,3 +52,32 @@ class GeckoDriverManager(WebDriverManagerBase):
             )
 
         return (url, os.path.split(urlparse(url).path)[1])
+
+    def get_latest_version(self):
+        return self._get_latest_version_with_github_page_fallback(self.gecko_driver_releases_url, self.fallback_url, "latest")
+
+    def get_compatible_version(self):
+        # Map browser version to webdriver version
+        # https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
+        browser_version = self._get_browser_version()
+        version_map = [(60, "v0.29.0"), (57, "v0.25.0"), (55, "v0.20.1"), (53, "v0.18.0"), (52, "v0.17.0")]
+
+        for browser_minimum, driver_version in version_map:
+            if browser_version >= browser_minimum:
+                return driver_version
+
+        raise_runtime_error(f"Unsupported Firefox version: {browser_version}")
+
+    def _get_browser_version(self):
+        cmd = self.firefox_version_commands.get(self.os_name)
+        if not cmd:
+            raise NotImplementedError("Unsupported system: %s", self.os_name)
+
+        output = get_output(cmd)
+        if not output:
+            raise_runtime_error("Error, unable to read current browser version")
+
+        version = output.split()[-1]
+        major = int(version.split(".")[0])
+
+        return major

--- a/src/webdrivermanager/gecko.py
+++ b/src/webdrivermanager/gecko.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import requests
 import os
+import re
 from urllib.parse import urlparse
 from .base import WebDriverManagerBase
 from .misc import LOGGER, raise_runtime_error, get_output
@@ -18,6 +19,7 @@ class GeckoDriverManager(WebDriverManagerBase):
         "linux": "geckodriver",
     }
 
+    firefox_version_pattern = r"(\d+)(\.\d+)"
     firefox_version_commands = {
         "win": ["reg", "query", r"HKEY_CURRENT_USER\Software\Mozilla\Mozilla Firefox", "/v", "CurrentVersion"],
         "linux": ["firefox", "--version"],
@@ -77,7 +79,8 @@ class GeckoDriverManager(WebDriverManagerBase):
         if not output:
             raise_runtime_error("Error, unable to read current browser version")
 
-        version = output.split()[-1]
-        major = int(version.split(".")[0])
+        version = re.search(self.firefox_version_pattern, output)
+        if not version:
+            raise_runtime_error("Error, browser version does not match known pattern")
 
-        return major
+        return int(version.group(1))

--- a/src/webdrivermanager/misc.py
+++ b/src/webdrivermanager/misc.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 import sys
 
 LOGGER = logging.getLogger(__name__)
@@ -15,3 +16,12 @@ def raise_runtime_error(msg):
 
 def versiontuple(v):
     return tuple(map(int, (v.split("."))))
+
+
+def get_output(cmd, **kwargs):
+    try:
+        output = subprocess.check_output(cmd, **kwargs)
+        return output.decode().strip()
+    except (FileNotFoundError, subprocess.CalledProcessError) as err:
+        LOGGER.debug("Command failed: %s", err)
+        return None

--- a/src/webdrivermanager/opera.py
+++ b/src/webdrivermanager/opera.py
@@ -18,13 +18,8 @@ class OperaChromiumDriverManager(WebDriverManagerBase):
     }
 
     def get_download_path(self, version="latest"):
-        if version == "latest":
-            ver = self._get_latest_version_with_github_page_fallback(
-                self.opera_chromium_driver_releases_url, self.fallback_url, version
-            )
-        else:
-            ver = version
-        return self.download_root / "operachromium" / ver
+        version = self._parse_version(version)
+        return self.download_root / "operachromium" / version
 
     def get_download_url(self, version="latest"):
         """
@@ -35,15 +30,11 @@ class OperaChromiumDriverManager(WebDriverManagerBase):
                         as specified on the download page of the webdriver binary.
         :returns: The download URL for the Opera Chromium driver binary.
         """
-        if version == "latest":
-            # TODO: convert to fstrings
-            opera_chromium_driver_version_release_url = self.opera_chromium_driver_releases_url + version
-        else:
-            # TODO: convert to fstrings
-            opera_chromium_driver_version_release_url = self.opera_chromium_driver_releases_url + "tags/" + version
+        version = self._parse_version(version)
+        releases_url = f"{self.opera_chromium_driver_releases_url}tags/{version}"
 
-        LOGGER.debug("Attempting to access URL: %s", opera_chromium_driver_version_release_url)
-        response = requests.get(opera_chromium_driver_version_release_url)
+        LOGGER.debug("Attempting to access URL: %s", releases_url)
+        response = requests.get(releases_url)
         if response.ok:
             url = self._parse_github_api_response(version, response)
         elif response.status_code == 403:
@@ -54,3 +45,11 @@ class OperaChromiumDriverManager(WebDriverManagerBase):
             )
 
         return (url, os.path.split(urlparse(url).path)[1])
+
+    def get_latest_version(self):
+        return self._get_latest_version_with_github_page_fallback(
+            self.opera_chromium_driver_releases_url, self.fallback_url, "latest"
+        )
+
+    def get_compatible_version(self):
+        raise NotImplementedError


### PR DESCRIPTION
I'm not sure what plans you had for this, but this is my small attempt at making the `compatible` option the default and a shared implementation. The need to call `_parse_version()` manually in implemented abstract methods is not ideal, but that was the easiest way to not break the API.

Changes include:
- abstract methods for resolving latest and compatible driver versions, with the latter having fallback to former
- baseclass method for parsing the version literals and calling relevant functions
- compatible as default downloaded version
- compatible support for Firefox (needs testing on Mac before release)