### PR TITLE
Clean error logging

### DIFF
--- a/src/webdrivermanager/__main__.py
+++ b/src/webdrivermanager/__main__.py
@@ -15,7 +15,7 @@ BITNESS = ["32", "64"]
 
 def parse_command_line():
     parser = argparse.ArgumentParser(
-        description="Tool for downloading and installing WebDriver binaries. Version: {get_versions()['version']}",
+        description=f"Tool for downloading and installing WebDriver binaries. Version: {get_versions()['version']}",
     )
     parser.add_argument(
         "browser",

--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -332,9 +332,10 @@ class WebDriverManagerBase:
             try:
                 symlink_stat = os.stat(symlink_src)
                 os.chmod(symlink_src, symlink_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-            except:
-                pass
+            except Exception:
                 # TODO: add error handling
+                pass
+
             return (symlink_src, symlink_target)
 
         # self.os_name == 'win':
@@ -350,8 +351,8 @@ class WebDriverManagerBase:
         try:
             dest_stat = os.stat(dest_file)
             os.chmod(dest_file, dest_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        except:
-            pass
+        except Exception:
             # TODO: add error handling
+            pass
 
         return (src_file, dest_file)

--- a/src/webdrivermanager/base.py
+++ b/src/webdrivermanager/base.py
@@ -148,7 +148,7 @@ class WebDriverManagerBase:
             except NotImplementedError:
                 pass
             except Exception as exc:
-                LOGGER.warning("Failed to parse compatible version: %s", exc)
+                LOGGER.info("Failed to parse compatible version: %s", exc)
             method = "latest"
 
         if method == "latest":

--- a/src/webdrivermanager/chrome.py
+++ b/src/webdrivermanager/chrome.py
@@ -105,4 +105,4 @@ class ChromeDriverManager(WebDriverManagerBase):
 
             return version.group(1)
 
-        raise_runtime_error("Error, unable to read current browser version")
+        raise RuntimeError("Unable to read current browser version")

--- a/src/webdrivermanager/gecko.py
+++ b/src/webdrivermanager/gecko.py
@@ -77,7 +77,7 @@ class GeckoDriverManager(WebDriverManagerBase):
 
         output = get_output(cmd)
         if not output:
-            raise_runtime_error("Error, unable to read current browser version")
+            raise RuntimeError("Unable to read current browser version")
 
         version = re.search(self.firefox_version_pattern, output)
         if not version:

--- a/src/webdrivermanager/misc.py
+++ b/src/webdrivermanager/misc.py
@@ -22,6 +22,10 @@ def get_output(cmd, **kwargs):
     try:
         output = subprocess.check_output(cmd, **kwargs, stderr=subprocess.STDOUT)
         return output.decode().strip()
-    except (FileNotFoundError, subprocess.CalledProcessError) as err:
-        LOGGER.debug("Command failed: %s", err)
+    except subprocess.CalledProcessError as err:
+        error = err.output.decode().strip()
+        LOGGER.debug("Command failed:\n%s", error)
+        return None
+    except FileNotFoundError as err:
+        LOGGER.debug("Command not found: %s", err)
         return None

--- a/src/webdrivermanager/misc.py
+++ b/src/webdrivermanager/misc.py
@@ -20,7 +20,7 @@ def versiontuple(v):
 
 def get_output(cmd, **kwargs):
     try:
-        output = subprocess.check_output(cmd, **kwargs)
+        output = subprocess.check_output(cmd, **kwargs, stderr=subprocess.STDOUT)
         return output.decode().strip()
     except (FileNotFoundError, subprocess.CalledProcessError) as err:
         LOGGER.debug("Command failed: %s", err)


### PR DESCRIPTION
Current compatible mode is a bit noisy if a used as a library, because of the following reasons:

- stderr from subprocesses is not captured and pollutes console
- no matching browser installed produces error log
- fallback from compatible to latest produces warning log

This PR tries to address those issues